### PR TITLE
[api] add new column `site_code`

### DIFF
--- a/.docker/postgres/Dockerfile
+++ b/.docker/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:10-alpine
+FROM postgres:12.6-alpine
 
 LABEL maintainer="Freshworks <web@freshworks.io>"
 

--- a/README.md
+++ b/README.md
@@ -69,18 +69,20 @@ Body:
 - `isEmptyTable` (boolean): Empty the `interpreter` table
 - `isAnonymous` (boolean): Anonymize the interpreter
 - `isVisual` (boolean): When uploading the `visual` interpreters, please use value: `true`
+- `isUpdate` (boolean): if want to update the exist interpreters, would take more time.
 
 3. For Regular Interpreters:
 
 - `file`
-- `isEmptyTable`: true
+- `isEmptyTable`: depends
 - `isAnonymous`: true, if env = 'test', 'dev'
+- `isUpdate`: true
 
 4. For Visual Interpreters:
 
 - `file`
 - `isAnonymous`: true, if env = 'test', 'dev'
-
+- `isUpdate`: true
 
 ## Add GUID to scope
 

--- a/api/package.json
+++ b/api/package.json
@@ -21,6 +21,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "migrate:create": "./node_modules/.bin/ts-node ./node_modules/.bin/typeorm migration:create -n $1",
     "migrate:run": "./node_modules/.bin/ts-node -r tsconfig-paths/register ./node_modules/.bin/typeorm migration:run",
+    "migrate:revert": "./node_modules/.bin/ts-node -r tsconfig-paths/register ./node_modules/.bin/typeorm migration:revert",
     "seed:config": "ts-node ./node_modules/typeorm-seeding/dist/cli.js config",
     "seed:run": "ts-node --project ./tsconfig.json -r tsconfig-paths/register ./node_modules/typeorm-seeding/dist/cli.js seed",
     "typedoc": "typedoc --disableOutputCheck",

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -22,7 +22,7 @@ import { UserEntity } from './user/entities/user.entity';
   imports: [
     ConfigModule.forRoot(),
     LoggerModule.forRoot({
-      pinoHttp: { prettyPrint: { colorize: true, singleLine: process.env.NODE_ENV === 'production' } },
+      pinoHttp: { prettyPrint: { colorize: true, singleLine: true } },
     }),
     DatabaseModule,
     InterpreterModule,

--- a/api/src/interpreter/dto/file-upload-interpreter.dto.ts
+++ b/api/src/interpreter/dto/file-upload-interpreter.dto.ts
@@ -25,4 +25,12 @@ export class FileUploadInterpreterDto {
   @IsOptional()
   @IsBoolean()
   isAnonymous?: boolean;
+
+  @ApiProperty({
+    description: 'if want to update table instead of empty table',
+    example: true,
+  })
+  @IsOptional()
+  @IsBoolean()
+  isUpdate?: boolean;
 }

--- a/api/src/interpreter/entities/interpreter.entity.ts
+++ b/api/src/interpreter/entities/interpreter.entity.ts
@@ -108,6 +108,13 @@ export class InterpreterEntity {
   @Column({ nullable: true, name: 'page12_contract' })
   page12ContractReceived: string;
 
+  @Column({
+    nullable: true,
+    name: 'site_code',
+  })
+  siteCode: string;
+
+  // relation pseudo columns
   @Column({ nullable: true, select: false, insert: false, readonly: true })
   intpAddr?: string;
 
@@ -149,6 +156,7 @@ export class InterpreterEntity {
       comments: this.comments,
       adminComments: this.adminComments,
       contractExtension: this.contractExtension,
+      siteCode: this.siteCode,
       intpAddr: this.intpAddr,
       distance: this.distance,
       createdAt: this.createdAt,

--- a/api/src/interpreter/interpreter.controller.ts
+++ b/api/src/interpreter/interpreter.controller.ts
@@ -17,12 +17,14 @@ import {
   Res,
 } from '@nestjs/common';
 import { Response } from 'express';
+import { ApiTags } from '@nestjs/swagger';
+import { PinoLogger, InjectPinoLogger } from 'nestjs-pino';
+
 import { InterpreterService } from './interpreter.service';
 import { CreateInterpreterDto } from './dto/create-interpreter.dto';
 import { UpdateInterpreterDto } from './dto/update-interpreter.dto';
 import { InterpreterEntity } from './entities/interpreter.entity';
 import { InterpreterRO } from './ro/interpreter.ro';
-import { ApiTags } from '@nestjs/swagger';
 
 import { PaginateInterpreterQueryDto } from './dto/paginate-interpreter-query.dto';
 import { UpdateObject } from 'src/common/interface/UpdateObject.interface';
@@ -59,6 +61,7 @@ export class InterpreterController {
     private readonly interpreterLanguageService: InterpreterLanguageService,
     private readonly distanceService: DistanceService,
     private readonly eventService: EventService,
+    @InjectPinoLogger(InterpreterController.name) private readonly logger: PinoLogger,
   ) {}
 
   @Post()
@@ -183,7 +186,10 @@ export class InterpreterController {
        * check if it's correct file type
        */
       if (file.mimetype !== 'text/csv') {
-        throw new Error('file type not correct');
+        throw new HttpException(
+          { status: HttpStatus.BAD_REQUEST, error: 'file type not correct' },
+          HttpStatus.BAD_REQUEST,
+        );
       }
 
       /**
@@ -210,6 +216,7 @@ export class InterpreterController {
         'comments',
         'adminComments',
         'contractExtension',
+        'siteCode',
       ];
       if (fileUploadInterpreterDto.isVisual) {
         headers = [
@@ -232,6 +239,7 @@ export class InterpreterController {
           'comments',
           'adminComments',
           'contractExtension',
+          'siteCode',
         ];
       }
 
@@ -241,7 +249,10 @@ export class InterpreterController {
       let json = await csvtojson({
         noheader: false,
         headers,
+        colParser: { siteCode: 'string' },
+        checkType: true, //otherwise, siteCode "1" becomes "01" (leading zero)
       }).fromString(file.buffer.toString());
+      this.logger.info(json, 'json');
 
       /**
        * mapping function to organize the dirty row json data
@@ -261,7 +272,12 @@ export class InterpreterController {
       /**
        * insert json to database
        */
-      const uploadedDirectories = await this.uploadDirectoriesToDatabase(directories);
+      let uploadedDirectories: InterpreterRO[] = [];
+      if (fileUploadInterpreterDto.isUpdate) {
+        uploadedDirectories = await this.upsertDirectoriesToDatabase(directories);
+      } else {
+        uploadedDirectories = await this.uploadDirectoriesToDatabase(directories);
+      }
 
       /**
        * return detail info
@@ -298,6 +314,48 @@ export class InterpreterController {
         }
 
         const interpreter = await this.interpreterService.create(createInterpreterDto, interpreterLangs);
+
+        return interpreter.toResponseObject();
+      }),
+    );
+  }
+
+  /**
+   * update json to database
+   * assume field "supplier" is unique
+   * @param directories
+   * @returns
+   */
+  private async upsertDirectoriesToDatabase(directories: CreateInterpreterDto[]) {
+    return Promise.all(
+      directories.map(async (createInterpreterDto: CreateInterpreterDto) => {
+        // langs
+        let interpreterLangs: InterpreterLanguageEntity[] = [];
+        const { languages, ...updateInterpreterDto } = createInterpreterDto;
+        if (languages && languages.length > 0) {
+          try {
+            interpreterLangs = await this.interpreterLanguageService.createMany(languages);
+          } catch (err) {
+            throw new HttpException(err, HttpStatus.BAD_REQUEST);
+          }
+        }
+
+        let interpreter: InterpreterEntity = null;
+        const existInterpreter = await this.interpreterService.findOneByKey('supplier', createInterpreterDto.supplier);
+        if (existInterpreter) {
+          // update exists interpreter
+          interpreter = await this.interpreterService.update(
+            existInterpreter.id,
+            updateInterpreterDto,
+            interpreterLangs,
+          );
+          this.logger.info(existInterpreter, 'exist interpreter');
+          this.logger.info(interpreter, 'updated interpreter');
+        } else {
+          // insert new interpreter
+          interpreter = await this.interpreterService.create(createInterpreterDto, interpreterLangs);
+          this.logger.info(interpreter, 'new interpreter');
+        }
 
         return interpreter.toResponseObject();
       }),

--- a/api/src/interpreter/interpreter.controller.ts
+++ b/api/src/interpreter/interpreter.controller.ts
@@ -250,7 +250,6 @@ export class InterpreterController {
         noheader: false,
         headers,
         colParser: { siteCode: 'string' },
-        checkType: true, //otherwise, siteCode "1" becomes "01" (leading zero)
       }).fromString(file.buffer.toString());
       this.logger.info(json, 'json');
 
@@ -341,7 +340,18 @@ export class InterpreterController {
         }
 
         let interpreter: InterpreterEntity = null;
-        const existInterpreter = await this.interpreterService.findOneByKey('supplier', createInterpreterDto.supplier);
+        let existInterpreter: InterpreterEntity = null;
+
+        if (createInterpreterDto.supplier) {
+          existInterpreter = await this.interpreterService.findOneByKey('supplier', createInterpreterDto.supplier);
+        } else if (createInterpreterDto.email) {
+          this.logger.info(createInterpreterDto, 'find user by email');
+          existInterpreter = await this.interpreterService.findOneByKey('email', createInterpreterDto.email);
+        } else {
+          this.logger.info(createInterpreterDto, 'has no identity to find the interpreter, return null');
+          return null;
+        }
+
         if (existInterpreter) {
           // update exists interpreter
           interpreter = await this.interpreterService.update(

--- a/api/src/interpreter/ro/interpreter.ro.ts
+++ b/api/src/interpreter/ro/interpreter.ro.ts
@@ -68,6 +68,9 @@ export class InterpreterRO {
   contractExtension: boolean;
 
   @ApiProperty()
+  siteCode: string;
+
+  @ApiProperty()
   intpAddr: string;
 
   @ApiProperty()

--- a/api/src/migrations/1620926295786-AddColumnSiteCodeInterpreter.ts
+++ b/api/src/migrations/1620926295786-AddColumnSiteCodeInterpreter.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+const Table = 'interpreter';
+
+export class AddColumnSiteCodeInterpreter1620926295786 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE ${Table} ADD COLUMN IF NOT EXISTS "site_code" character varying;`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE ${Table} DROP COLUMN IF EXISTS "site_code";`);
+  }
+}

--- a/api/src/migrations/1620969552565-UpdateEnumStatusBooking.ts
+++ b/api/src/migrations/1620969552565-UpdateEnumStatusBooking.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UpdateEnumStatusBooking1620969552565 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `
+        DO $$
+        BEGIN
+            IF  EXISTS (SELECT 1 FROM pg_type WHERE typname = 'booking_status_enum') THEN
+                ALTER TYPE "booking_status_enum" RENAME VALUE 'CANCELLED' TO 'Cancelled';
+            END IF;
+        END
+        $$; 
+    `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `
+          DO $$
+          BEGIN
+              IF  EXISTS (SELECT 1 FROM pg_type WHERE typname = 'booking_status_enum') THEN
+                  ALTER TYPE "booking_status_enum" RENAME VALUE 'Cancelled' TO 'CANCELLED';
+              END IF;
+          END
+          $$; 
+      `,
+    );
+  }
+}


### PR DESCRIPTION
- add new command on `package.json` for reverting migration. (for future usage if needed)
(fact: revert command only revert one step each time)
- add new migration; 
- add to entity,dto,ro; 
- modify endpoint; 
- update export interpreter csv;

- update enum `booking_status_enum` from "CANCELLED" to "Cancelled"
- update docker postgres to version 12.6 same as openshift