### PR TITLE
Cypress tests for creating and updating a booking

### DIFF
--- a/e2e/cypress/fixtures/bookings/booking.json
+++ b/e2e/cypress/fixtures/bookings/booking.json
@@ -16,9 +16,10 @@
   "file": "1230123",
   "interpretFor": "defendant",
   "requestedBy": "defendant",
-  "federal": "no",
+  "federal": false,
   "language": "French",
-  "reason": "Everyone likes french",
+  "reason": "FA",
   "prosecutor": "George",
-  "comment": "Standard issue"
+  "comment": "Standard issue",
+  "locationId": 2
 }

--- a/e2e/cypress/integration/create-bookings.spec.js
+++ b/e2e/cypress/integration/create-bookings.spec.js
@@ -39,7 +39,6 @@ describe('Create Booking', {
     cy.get(`input[name='language']`).type('French')
     cy.get(`button[type='submit']`).click()
     cy.get('tr').find('td span').contains('French').should('not.be.empty')
-
     cy.get(`input[name='language']`).clear().type('french')
     cy.get(`button[type='submit']`).click()
     cy.get('tr').find('td span').contains('French').should('not.be.empty')
@@ -53,6 +52,34 @@ describe('Create Booking', {
     cy.get('span.nice-dates-day:not(.-disabled) span.nice-dates-day_date').eq(3).click()
     cy.get('button').contains('Add').click()
     cy.get('.searchDate').should('have.length', 3)
+  })
+
+  it('Creates a new booking', () => {
+    cy.visit('/create')
+    // type french, select days and search
+    cy.get(`input[name='language']`).type('French')
+    cy.get('#rangeCalButton').click()
+    cy.get('span.nice-dates-day:not(.-disabled) span.nice-dates-day_date').eq(1).click()
+    cy.get('span.nice-dates-day:not(.-disabled) span.nice-dates-day_date').eq(2).click()
+    cy.get('span.nice-dates-day:not(.-disabled) span.nice-dates-day_date').eq(3).click()
+    cy.get('button').contains('Add').click()
+    cy.get(`button[type='submit']`).click()
+    
+    // open booking modal, fill in fields
+    cy.get(`.intSearchButton button[type='button']`).contains('Book').click()
+    cy.get(`input[name='room']`).type('101b')
+    cy.get(`input[name='file']`).type('121')
+    cy.get(`input[name='locationId']`).type('Vancouver')
+    cy.get('li').contains('Vancouver Law Courts').click()
+    cy.get(`input[name='caseName']`).type('Test vs Try')
+    cy.get(`input[name='federal'][value='no']`).click()
+    cy.get(`input[name='reason']`).type('FA')
+    cy.get(`input[name='prosecutor']`).type('Harry')
+    cy.get(`textarea[name='comment']`).type('No comment')
+    cy.get(`button[type='button']`).contains('Create Booking').click()
+    // check redirect and presence of new booking
+    cy.location('href').should('include', 'bookings')
+    cy.contains('Test vs Try')
   })
 
   it('Authenticates to the API', () => {

--- a/e2e/cypress/integration/directory.spec.js
+++ b/e2e/cypress/integration/directory.spec.js
@@ -1,0 +1,74 @@
+describe('Directory', {
+  retries: 2
+}, () => {
+
+  before(() => {
+    cy.clearDb()
+
+    cy.kcLogout()
+    cy.kcLogin('cypress-admin').as('tokens')
+
+    cy.fixture('interpreters/interpreters.json').then((interpreters) => {
+      cy.get('@tokens').then(tokens => {
+        cy.request({
+          method: 'POST',
+          url: Cypress.env('API_URL') + '/interpreter/upload',
+          auth: {
+            bearer: tokens.access_token
+          },
+          body: interpreters
+        })
+      })
+    })
+  })
+
+  beforeEach(() => {
+    cy.kcLogout()
+    cy.kcLogin('cypress-admin').as('tokens')
+  })
+
+  it('Loads the directory page', () => {
+    cy.visit('/directory')
+    cy.location('href').should('include', 'directory')
+    cy.contains('Search Interpreters')
+    cy.get(`button[type='submit']`).contains('Search').should('not.be.empty')
+  })
+
+  it('Searches by language, case insensitive', () => {
+    cy.visit('/directory')
+    cy.get(`input[name='language']`).type('French')
+    cy.get(`button[type='submit']`).click()
+    cy.get('tr').find('td span').contains('French').should('not.be.empty')
+
+    cy.get(`input[name='language']`).clear().type('french')
+    cy.get(`button[type='submit']`).click()
+    cy.get('tr').find('td span').contains('French').should('not.be.empty')
+  })
+
+  it('Filters by level', () => {
+    cy.visit('/directory')
+    cy.get(`input[name='language']`).clear().type('Russian')
+    cy.get(`input[name='level'][value='1']`).click()
+    cy.get(`input[name='level'][value='2']`).click()
+    cy.get(`button[type='submit']`).click()
+    cy.get('tr').contains('Russian').should('have.length', 1)
+  })
+  
+  it('Filters by name', () => {
+    cy.visit('/directory')
+    cy.get(`input[name='name']`).clear().type('Alex')
+    cy.get(`button[type='submit']`).click()
+    cy.get('tr').not('.MuiTableRow-head').not('.MuiTableRow-footer').not(':empty').should('have.length', 1)
+  })
+
+  it('Authenticates to the API', () => {
+    cy.get('@tokens').then(tokens => {
+      cy.request({
+        url: Cypress.env('API_URL') + '/interpreter',
+        auth: {
+          bearer: tokens.access_token
+        }
+      }).its('status').should('eq', 200)
+    })
+  })
+})

--- a/e2e/cypress/integration/update-bookings.spec.js
+++ b/e2e/cypress/integration/update-bookings.spec.js
@@ -1,0 +1,94 @@
+describe('Update Booking', {
+  retries: 2
+}, () => {
+
+  before(() => {
+
+    cy.clearDb()
+
+    cy.kcLogout()
+    cy.kcLogin('cypress-admin').as('tokens')
+    cy.fixture('interpreters/interpreters.json').then((interpreters) => {
+      cy.get('@tokens').then(tokens => {
+        cy.request({
+          method: 'POST',
+          url: Cypress.env('API_URL') + '/interpreter/upload',
+          auth: {
+            bearer: tokens.access_token
+          },
+          body: interpreters
+        })
+          .then((response) => {
+            cy.fixture('bookings/booking.json').then((booking) => {
+              cy.request({
+                method: 'POST',
+                url: Cypress.env('API_URL') + '/booking',
+                auth: { bearer: tokens.access_token },
+                body: { ...booking, interpreterId: response.body[0].id }
+              })
+            })
+          })
+      })
+    })
+  })
+
+  beforeEach(() => {
+    cy.kcLogout()
+    cy.kcLogin('cypress-admin').as('tokens')
+  })
+  
+  it('Updates a booking status to booked', () => {
+    cy.visit('/bookings')
+    cy.get('input#interpreter').type('Mona')
+    cy.get(`button[type='submit']`).click()
+    cy.get(`[title='Edit Booking']`).click()
+    cy.wait(500)
+    cy.get('select#status').select('Booked')
+    cy.get('button').contains('Update Booking').click()
+    cy.contains('Booked')
+  })
+
+  it('Updates a booking to pending', () => {
+    cy.visit('/bookings')
+    cy.get('input#interpreter').type('Mona')
+    cy.get(`button[type='submit']`).click()
+    cy.get(`[title='Edit Booking']`).click()
+    cy.wait(500)
+    cy.get('select#status').select('Pending')
+    cy.get('button').contains('Update Booking').click()
+    cy.contains('Pending')
+  })
+  
+  it('Updates a booking status to cancelled', () => {
+    cy.visit('/bookings')
+    cy.get('input#interpreter').type('Mona')
+    cy.get(`button[type='submit']`).click()
+    cy.get(`[title='Edit Booking']`).click()
+    cy.wait(500)
+    cy.get('select#status').select('Cancelled')
+    cy.get('button').contains('Update Booking').click()
+    cy.contains('Cancelled')
+  })
+
+  it('Updates a booking location', () => {
+    cy.server()
+    cy.route({
+      method: 'PATCH',
+      url: '/api/v1/booking/*',
+    }).as('updateBookingRequest')
+
+    cy.visit('/bookings')
+    cy.get('input#interpreter').type('Mona')
+    cy.get(`button[type='submit']`).click()
+    cy.get(`[title='Edit Booking']`).click()
+    cy.wait(500)
+    cy.get(`.MuiDialogContent-root input[name='locationId']`).type('Victoria')
+    cy.get('li').contains('Victoria').click()
+    cy.get('button').contains('Update Booking').click()
+    
+    cy.wait('@updateBookingRequest').then(({ requestBody, responseBody, status }) => {
+      expect(status).to.eq(200)
+    })
+  })
+
+})

--- a/frontend/src/components/form/DirectorySearch.tsx
+++ b/frontend/src/components/form/DirectorySearch.tsx
@@ -24,7 +24,6 @@ import Check from 'components/form/inputs/Check';
 import { StyledButton } from 'components/Buttons';
 
 import InterpreterSearchContext from 'contexts/InterpreterSearchContext';
-import { languages } from 'constants/languages';
 import { courtLocations } from 'constants/courtLocations';
 import { InterpreterSearchParams } from 'constants/interfaces';
 import { ErrorMessage, Field, Formik, FormikProps, FieldProps } from 'formik';


### PR DESCRIPTION
Turns out Cypress has had two major version updates since we installed it, this PR uses the old API for intercepting network requests and asserting on their status/response etc, as we are on 5.50

https://docs.cypress.io/api/commands/intercept#Syntax-and-Usage