### PR TITLE
CSBISS-499: fix: prevent interpreter details from showing incorrect data

### DIFF
--- a/web/src/components/tabs/components/AdmForms/pdf/Authorizations.vue
+++ b/web/src/components/tabs/components/AdmForms/pdf/Authorizations.vue
@@ -52,7 +52,7 @@
                     <td />
                     <td class="">
                         I certify this is a true statement of disbursements made a entitled as a result of 
-                        travel on government business as have not been and will not be reimbursed by any other party</td>                                              
+                        travel on government business as have not been and will not be reimbursed by any other party.</td>                                              
                     <td class=""></td>
                     <td class=""></td>
                     <td class=""></td>

--- a/web/src/components/tabs/components/InterpreterDetails.vue
+++ b/web/src/components/tabs/components/InterpreterDetails.vue
@@ -22,7 +22,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from 'vue-property-decorator';
+import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 import { interpreterInfoType } from '@/types/Interpreters/json';
 
 @Component
@@ -41,6 +41,11 @@ export default class InterpreterDetails extends Vue {
     fullAddress = '';
 
     detailedFields = [];
+
+    @Watch('interpreterDetails')
+    onInterpreterDetailsChanged() {
+        this.extractDetails();
+    }
    
     detailedDirectoryFields = [              
         {

--- a/web/src/components/tabs/components/InterpreterDetailsCard.vue
+++ b/web/src/components/tabs/components/InterpreterDetailsCard.vue
@@ -44,7 +44,7 @@
                             <scheduling-conflict-popup :bookings="interpreter.booking" :bookingDates="bookingDates" :searchLocation="searchLocation"/>
                     </b-popover>
             </div>
-            <b-button variant="transparent" class="border-0 ml-3" @click="showInterpreterDetailsWindow = true">
+            <b-button variant="transparent" class="border-0 ml-3" @click="extractInterpreterDetails(); showInterpreterDetailsWindow = true">
                 <b class="text-primary">
                     More Details
                 </b>
@@ -110,7 +110,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from 'vue-property-decorator';
+import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 import * as _ from 'underscore';
 import { interpreterInfoType } from '@/types/Interpreters/json';
 import { bookingDateTimesInfoType } from '@/types/Bookings/json';
@@ -154,6 +154,11 @@ export default class InterpreterDetailsCard extends Vue {
 
     interpreterDetails =[]
 
+    @Watch('interpreter')
+    onInterpreterChanged() {
+        this.extractInterpreterDetails();
+    }
+
     mounted(){
         this.dataLoaded = false;        
         this.extractInterpreterDetails()
@@ -189,6 +194,7 @@ export default class InterpreterDetailsCard extends Vue {
 
 
     public bookInterpreter(){        
+        this.extractInterpreterDetails();
         this.showBookingWindow = true;                
     }
 
@@ -199,7 +205,8 @@ export default class InterpreterDetailsCard extends Vue {
     }
     
     public closeBookingWindow(){
-        this.showBookingWindow = false; 
+        this.showBookingWindow = false;
+        this.interpreterDetails = [];
     }
 }
 </script>

--- a/web/src/components/tabs/components/SearchInterpretersCalendarTable.vue
+++ b/web/src/components/tabs/components/SearchInterpretersCalendarTable.vue
@@ -31,6 +31,7 @@
 
                     <template v-slot:cell(interpreter)="data" >                    
                         <interpreter-details-card 
+                            :key="data.item.id"
                             :interpreter="data.item"
                             :bookingDates="bookingDates"
                             :searchLocation="searchLocation"

--- a/web/src/components/tabs/components/SearchInterpretersTable.vue
+++ b/web/src/components/tabs/components/SearchInterpretersTable.vue
@@ -144,7 +144,7 @@
                     </template>
                     <template v-slot:row-details="data">
                         <b-card bg-variant="inactive" class="mb-3" border-variant="white" body-class="px-1 pt-0 pb-1">                                                     
-                            <interpreter-details :interpreterDirectory="false" :interpreterDetails="data.item" />
+                            <interpreter-details :key="data.item.id" :interpreterDirectory="false" :interpreterDetails="data.item" />
                         </b-card>
                     </template>
                     


### PR DESCRIPTION
https://jira.justice.gov.bc.ca/browse/CSBISS-499

prevent interpreter details from showing incorrect data across profiles

Root cause: Vue component instances were being reused without updating their local state when interpreter props changed.

Changes:
- Add `@Watch` decorators to `InterpreterDetailsCard` and `InterpreterDetails` to re-extract details when interpreter prop changes
- Trigger data refresh when opening interpreter detail modals
- Add state cleanup on modal close to prevent residual data bleed
- Add stable :key bindings (interpreter.id) to force proper component lifecycle management in `SearchInterpretersCalendarTable` and `SearchInterpretersTable`