### PR TITLE
CSBISS-527: Rounding off issue for cancellation fee.

### DIFF
--- a/web/src/components/tabs/components/AdmForms/AdmCalculations/CancellationCalculation.ts
+++ b/web/src/components/tabs/components/AdmForms/AdmCalculations/CancellationCalculation.ts
@@ -155,6 +155,7 @@ function getTotalCancellations(
     totalCancelledHrMax = 20;   // 11-15 days: 20h
   else if (totalCancelledHr > fifteendays) totalCancelledHrMax = 25; // 16+ days: 25h
 
+  //The + 0.0001 is typically added as a small floating-point correction to avoid JavaScript precision issues during currency calculations
   cancellationFee = Number((totalCancelledHrMax * Number(bestRate) + 0.0001));
 
   const gstNumber = booking?.interpreter?.gst;

--- a/web/src/components/tabs/components/AdmForms/AdmCalculations/CancellationCalculation.ts
+++ b/web/src/components/tabs/components/AdmForms/AdmCalculations/CancellationCalculation.ts
@@ -155,7 +155,7 @@ function getTotalCancellations(
     totalCancelledHrMax = 20;   // 11-15 days: 20h
   else if (totalCancelledHr > fifteendays) totalCancelledHrMax = 25; // 16+ days: 25h
 
-  cancellationFee = bestRate * totalCancelledHrMax;
+  cancellationFee = Number((totalCancelledHrMax * Number(bestRate) + 0.0001));
 
   const gstNumber = booking?.interpreter?.gst;
   if (!gstRate)


### PR DESCRIPTION
Description: Cancellation fee round-off issue.

Fix Detail: The + 0.0001 is typically added as a small floating-point correction to avoid JavaScript precision issues during currency calculations.

Test case Verified:
1. Create new booking
2. Cancel booking
3. Approve ADM-322 form
4. Verify the cancellation details in pdf generated

Screenshot:
<img width="1380" height="335" alt="image" src="https://github.com/user-attachments/assets/c2e90784-173a-466a-94cf-86a1f4172ae7" />

