### PR TITLE
CSBISS-539: Interpreters export issue. Export aligned with search filter

### DIFF
--- a/api/api/repository/interpreter_transactions.py
+++ b/api/api/repository/interpreter_transactions.py
@@ -17,6 +17,7 @@ from fastapi import HTTPException
 from sqlalchemy.orm import Session
 from sqlalchemy import func, or_
 from api.schemas.interpreter_schema import InterpreterCreateModifyRequestSchema
+from api.repository.search_interpreter_transactions import fetch_interpreters
 
 from core.geo_coordinate_service import get_clean_address
 
@@ -251,12 +252,9 @@ def apply_address_changes(old_interpreter, interpreter_request):
 
 
 
-def get_filepath_of_excel_sheet_have_interpreters_data(interpreter_request, db: Session):
+def get_filepath_of_excel_sheet_have_interpreters_data(interpreter_request, db: Session, username):
 
-    interpreters = db.query(InterpreterModel).filter(
-        InterpreterModel.disabled==False,
-        InterpreterModel.id.in_(interpreter_request.ids)
-    ).all()
+    interpreters, _ = fetch_interpreters(interpreter_request, db, username)
     
     csv_file = io.StringIO()
     column_names = InterpreterModel.__table__.columns.keys()

--- a/api/api/repository/search_interpreter_transactions.py
+++ b/api/api/repository/search_interpreter_transactions.py
@@ -16,6 +16,18 @@ from models.booking_enums import BookingStatusEnum, BookingPeriodEnum
 
 def search_Interpreter(request: InterpreterSearchRequestSchema, db: Session, username, response_schema):
 
+    
+    all_interpreters, total_count_of_filtered_interpreters = fetch_interpreters(request, db, username)
+
+    return PaginatedResponse(
+        total=total_count_of_filtered_interpreters,
+        items=[response_schema.from_orm(interpreter) for interpreter in all_interpreters],
+        page=request.page,
+        limit=request.limit
+    )
+
+def fetch_interpreters(request: InterpreterSearchRequestSchema, db: Session, username):
+
     if not check_user_roles(['cis-admin','super-admin'],username,db):
         request.active = True
 
@@ -38,19 +50,17 @@ def search_Interpreter(request: InterpreterSearchRequestSchema, db: Session, use
     # apply sorting
     # interpreter = apply_sorting(interpreter, request.sort)
     # apply pagination
-    interpreter = apply_pagination(interpreter, request.limit, request.page)
+    fields_set = getattr(request, 'model_fields_set', getattr(request, '__fields_set__', set()))
+    
+    if 'limit' in fields_set and 'page' in fields_set and request.limit is not None and request.page is not None:
+        interpreter = apply_pagination(interpreter, request.limit, request.page)
 
     # run query to get data
     all_interpreters = interpreter.all()
 
-    all_interpreters = add_court_info(all_interpreters, request.location, db)
+    return add_court_info(all_interpreters, request.location, db), total_count_of_filtered_interpreters
 
-    return PaginatedResponse(
-        total=total_count_of_filtered_interpreters,
-        items=[response_schema.from_orm(interpreter) for interpreter in all_interpreters],
-        page=request.page,
-        limit=request.limit
-    )
+   
 
 def apply_pagination(interpreter, limit, page): 
     if limit is not None and page is not None: 

--- a/api/api/routers/interpreter_router.py
+++ b/api/api/routers/interpreter_router.py
@@ -48,7 +48,7 @@ def get_All_Interpreters(db: Session= Depends(get_db_session), user = Depends(ad
 
 @router.post('/download-data-in-excel', status_code=status.HTTP_200_OK, response_class=FileResponse)
 def get_All_Interpreters_In_Excel(request: InterpreterDataInExcelRequestSchema, background_task: BackgroundTasks, db: Session = Depends(get_db_session), user = Depends(admin_user)):
-    return get_filepath_of_excel_sheet_have_interpreters_data(request, db) 
+    return get_filepath_of_excel_sheet_have_interpreters_data(request, db, user['username']) 
 
 
 

--- a/api/api/schemas/interpreter_search_schema.py
+++ b/api/api/schemas/interpreter_search_schema.py
@@ -18,8 +18,7 @@ class CrcDateRangeSchema(BaseModel):
     endDate: Optional[str]
     startDate: Optional[str]
 
-
-class InterpreterSearchRequestSchema(BaseModel):    
+class BaseInterpreterSearchSchema(BaseModel):    
     languageId:  Optional[int]
     level: Optional[List[str]]
     city: Optional[str]
@@ -31,6 +30,8 @@ class InterpreterSearchRequestSchema(BaseModel):
     courtAddr: Optional[str]
     distanceLimit: Optional[bool]
     location: Optional[LocationSchema]
+
+class InterpreterSearchRequestSchema(BaseInterpreterSearchSchema):    
     limit: Optional[int]
     page: Optional[int]
     # sort: Optional[str]
@@ -46,6 +47,6 @@ class InterpreterSearchResponseSchema(InterpreterBase):
     court_distance: Optional[int] = Field(alias="courtDistance")    
 
 
-class InterpreterDataInExcelRequestSchema(BaseModel):
-    ids: List[int]
+class InterpreterDataInExcelRequestSchema(BaseInterpreterSearchSchema):
+    pass
 

--- a/web/src/components/tabs/Admin/Directory.vue
+++ b/web/src/components/tabs/Admin/Directory.vue
@@ -950,9 +950,15 @@ export default class DirectoryPage extends Vue {
             "Content-Type": "application/json",
             }
         }
-
-        const body = {            
-            "ids":this.interpreters.map(interpreter=>interpreter.id)
+        const language = this.languages.filter(lang => lang.name==this.language);
+        const body = {
+            "name":this.name,
+            "active":this.active,
+            "languageId":language.length==1? language[0].id :null,
+            "level":this.level,
+            "city":'',
+            "keywords":this.keyword,
+            "criminalRecordCheck":this.crcExpiryDate,
         }
         
         this.$http.post('/interpreter/download-data-in-excel',body, options)


### PR DESCRIPTION

Description: Export was only pulling the data from table grid; discarding the actual search filter.

Test cases Ran:
Post setup of adding interpreters (Count-4).
Test Case#1:  No Filter -> Export interpreters [Expected: 4 | Actual: 4].
Test Case#2:  Filter by First Name -> Export interpreters [Expected: 1 | Actual: 1].
Test Case#3:  Filter by CRC Expiry -> Export interpreters [Expected: 1 | Actual: 1].

Screenshot from Test Case#3: Reference
<img width="1883" height="646" alt="image" src="https://github.com/user-attachments/assets/d6cb4a9b-2877-4c3a-be68-7517614a4317" />

<img width="1316" height="330" alt="image" src="https://github.com/user-attachments/assets/87e913d3-a53f-488c-bcaa-7c0097103703" />

